### PR TITLE
Add Location field to events

### DIFF
--- a/Migrations/20250604090121_AddLocationToEventModel.Designer.cs
+++ b/Migrations/20250604090121_AddLocationToEventModel.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EventTracker.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EventTracker.Migrations
 {
     [DbContext(typeof(EventContext))]
-    partial class EventContextModelSnapshot : ModelSnapshot
+    [Migration("20250604090121_AddLocationToEventModel")]
+    partial class AddLocationToEventModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.5");

--- a/Migrations/20250604090121_AddLocationToEventModel.cs
+++ b/Migrations/20250604090121_AddLocationToEventModel.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EventTracker.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLocationToEventModel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Location",
+                table: "Events",
+                type: "TEXT",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.UpdateData(
+                table: "Events",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "Location",
+                value: "Ankara, Türkiye");
+
+            migrationBuilder.UpdateData(
+                table: "Events",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "Location",
+                value: "İstanbul, Türkiye");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Location",
+                table: "Events");
+        }
+    }
+}

--- a/Models/EventContext.cs
+++ b/Models/EventContext.cs
@@ -22,6 +22,7 @@ public class EventContext : DbContext
                 Id = 1,
                 Title = "Örnek Etkinlik 1",
                 Description = "ilk etkinlik için açıklama.",
+                Location = "Ankara, Türkiye",
                 Date = new System.DateTime(2025, 01, 15, 14, 00, 00)
             },
 
@@ -30,6 +31,7 @@ public class EventContext : DbContext
                 Id = 2,
                 Title = "Örnek Etkinlik 2",
                 Description = "ikinci etkinlik için açıklama.",
+                Location = "İstanbul, Türkiye",
                 Date = new System.DateTime(2025, 02, 20, 18, 30, 00)
             }
 

--- a/Models/EventModel.cs
+++ b/Models/EventModel.cs
@@ -14,6 +14,9 @@ public class EventModel
 
     public string? Description { get; set; }
 
+    [StringLength(200, ErrorMessage = "Adres 200 karakterden uzun olamaz")]
+    public string? Location { get; set; }
+
     [Required(ErrorMessage = "Etkinlik tarihi zorunludur.")]
     public DateTime Date { get; set; } // Etkinlik tarihi (ve saati)
 


### PR DESCRIPTION
## Summary
- add `Location` property to `EventModel`
- seed sample locations in `EventContext`
- create `AddLocationToEventModel` EF Core migration

## Testing
- `dotnet build`
- `dotnet ef database update`


------
https://chatgpt.com/codex/tasks/task_e_68400a875c2c83289f1243ec510bf67e