### PR TITLE
Update CI test configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: .NET CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
+      - run: dotnet restore
+      - run: dotnet build --configuration Release
+      - run: dotnet test --no-build --configuration Release


### PR DESCRIPTION
## Summary
- adjust the dotnet test step to use Release output

## Testing
- `dotnet restore EventTracker.sln`
- `dotnet build EventTracker.sln --configuration Release`
- `dotnet test EventTracker.sln --no-build --configuration Release`


------
https://chatgpt.com/codex/tasks/task_e_68402dbf850483289484ee76dda076f3