### PR TITLE
Hide join button for past events

### DIFF
--- a/EventTracker.Tests/EventModelTests.cs
+++ b/EventTracker.Tests/EventModelTests.cs
@@ -1,0 +1,22 @@
+using System;
+using NUnit.Framework;
+using EventTracker.Models;
+
+namespace EventTracker.Tests;
+
+public class EventModelTests
+{
+    [Test]
+    public void IsPast_ReturnsTrue_WhenDateInPast()
+    {
+        var model = new EventModel { Date = DateTime.Now.AddDays(-1) };
+        Assert.That(model.IsPast, Is.True);
+    }
+
+    [Test]
+    public void IsPast_ReturnsFalse_WhenDateInFuture()
+    {
+        var model = new EventModel { Date = DateTime.Now.AddDays(1) };
+        Assert.That(model.IsPast, Is.False);
+    }
+}

--- a/Models/EventModel.cs
+++ b/Models/EventModel.cs
@@ -20,5 +20,7 @@ public class EventModel
     [Required(ErrorMessage = "Etkinlik tarihi zorunludur.")]
     public DateTime Date { get; set; } // Etkinlik tarihi (ve saati)
 
+    public bool IsPast => Date < DateTime.Now;
+
 }
 

--- a/Views/Events/Index.cshtml
+++ b/Views/Events/Index.cshtml
@@ -27,7 +27,10 @@
                 <td>@evt.Description</td>
                 <td>@evt.Date.ToString("g")</td>
                 <td>
-                    <a asp-action="Details" asp-route-id="@evt.Id" class="btn btn-info btn-sm"></a>
+                    @if (!evt.IsPast)
+                    {
+                        <a asp-action="Details" asp-route-id="@evt.Id" class="btn btn-info btn-sm">Katıl</a>
+                    }
                     <a asp-action="Edit" asp-route-id="@evt.Id" class="btn btn-primary btn-sm">Düzenle</a>
                     <a asp-action="Delete" asp-route-id="@evt.Id" class="btn btn-danger btn-sm"
                         onclick="return confirm('Bu etkinliği silmek istediğinize emin misiniz=');">Sil</a>


### PR DESCRIPTION
## Summary
- add `IsPast` property to `EventModel`
- show `Katıl` button only for future events
- add NUnit tests for `EventModel.IsPast`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840360a42bc8328b4f0fbd7ff9a731f